### PR TITLE
Change node_js version from lts/* to 10.17.0

### DIFF
--- a/appcenter/continuous-integration.md
+++ b/appcenter/continuous-integration.md
@@ -18,7 +18,7 @@ In order to build your app using Houston CI, Travis requires a configuration fil
 language: node_js
 
 node_js:
-  - lts/*
+  - 10.17.0
 
 sudo: required
 


### PR DESCRIPTION
I changed the version on the `.travis.yaml` file to `10.17.01` because with latest LTS ( `v12.18.3` ) it was failing. 
I choose version 10.17.0 because I notices that Planner was working with that version. I haven't tested with others.

Here's the error with LTS ( `v12.18.3` ) :
```
nodegit.target.mk:255: recipe for target 'Release/obj.target/nodegit/src/promise_completion.o' failed

make: *** [Release/obj.target/nodegit/src/promise_completion.o] Error 1

make: Leaving directory '/home/travis/.nvm/versions/node/v12.18.3/lib/node_modules/@elementaryos/houston/node_modules/nodegit/build'

gyp

ERR! build error

gyp ERR! stack Error: `make` failed with exit code: 2

gyp ERR! stack     at ChildProcess.onExit (/home/travis/.nvm/versions/node/v12.18.3/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)

gyp ERR! stack     at ChildProcess.emit (events.js:315:20)

gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)

gyp ERR! System Linux 4.15.0-1077-gcp
```
