### PR TITLE
Change license in metadata to GPL for consistency

### DIFF
--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -75,7 +75,7 @@ Every app also comes with an .appdata.xml file. This file contains all the infor
    <!-- Copyright 2019 Your Name <you@email.com> -->
    <component type="desktop">
      <id>com.github.yourusername.yourrepositoryname</id>
-     <metadata_license>CC0</metadata_license>
+     <metadata_license>GPL</metadata_license>
      <name>Your App's Name</name>
      <summary>A Catchy Tagline</summary>
      <description>


### PR DESCRIPTION
In the previous page, it mentions that you should add a GPL header to your files. For consistency, the metadata should display that license (also, as Lessig once told me, CC0 – or any Creative Commons licenses – should not be used for software as they do not include limitation of liability clauses).