### PR TITLE
packaging: Replace priority extra with optional

### DIFF
--- a/writing-apps/our-first-app/packaging.md
+++ b/writing-apps/our-first-app/packaging.md
@@ -42,7 +42,7 @@ Now it's time to create the rules that will allow your app to be built as a .deb
    ```text
    Source: com.github.yourusername.yourrepositoryname
    Section: x11
-   Priority: extra
+   Priority: optional
    Maintainer: Your Name <you@emailaddress.com>
    Build-Depends: debhelper (>= 10.5.1),
                   gettext,


### PR DESCRIPTION
It seems to be deprecated: https://lintian.debian.org/tags/priority-extra-is-replaced-by-priority-optional.html
