### PR TITLE
Use new Meson paths syntax

### DIFF
--- a/apis/state-saving.md
+++ b/apis/state-saving.md
@@ -52,7 +52,7 @@ You can read more about [`GLib.Settings.bind ()` on Valadoc](https://valadoc.org
 
 We need to add the new GSchema XML file to our build system so it is included at install time. Create a file `data/meson.build` and type the following:
 
-```text
+```coffeescript
 install_data (
     'gschema.xml',
     install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',

--- a/apis/state-saving.md
+++ b/apis/state-saving.md
@@ -55,8 +55,8 @@ We need to add the new GSchema XML file to our build system so it is included at
 ```text
 install_data (
     'gschema.xml',
-    install_dir: join_paths (get_option ('datadir'), 'glib-2.0', 'schemas'),
-    rename: meson.project_name () + '.gschema.xml'
+    install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
+    rename: meson.project_name() + '.gschema.xml'
 )
 ```
 
@@ -79,7 +79,7 @@ if not os.environ.get('DESTDIR'):
 
 Be sure to add the following lines to the end of the meson.build file in your source root so that Meson knows where to find the additional instructions we've added:
 
-```text
+```coffeescript
 meson.add_install_script('meson/post_install.py')
 
 subdir('data')

--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -15,7 +15,7 @@ project('com.github.yourusername.yourrepositoryname', 'vala', 'c')
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install
 executable(
     meson.project_name(),
-    'src/Application.vala',
+    'src' / 'Application.vala',
     dependencies: [
         dependency('gtk+-3.0')
     ],
@@ -24,15 +24,15 @@ executable(
 
 # Install our .desktop file so the Applications Menu will see it
 install_data(
-    join_paths('data', 'hello-again.desktop'),
-    install_dir: join_paths(get_option('datadir'), 'applications'),
+    'data' / 'hello-again.desktop',
+    install_dir: get_option('datadir') / 'applications',
     rename: meson.project_name() + '.desktop'
 )
 
 # Install our .appdata.xml file so AppCenter will see it
 install_data(
-    join_paths('data', 'hello-again.appdata.xml'),
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    'data' / 'hello-again.appdata.xml',
+    install_dir: get_option('datadir') / 'metainfo',
     rename: meson.project_name() + '.appdata.xml'
 )
 

--- a/writing-apps/our-first-app/translations.md
+++ b/writing-apps/our-first-app/translations.md
@@ -16,7 +16,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
 
 1. Open up your "meson.build" file and add these lines below your project declaration:
 
-   ```text
+   ```coffeescript
    # Include the translations module
    i18n = import('i18n')
 
@@ -26,24 +26,24 @@ Now we have to make some changes to our Meson build system and add a couple new 
 
 2. Remove the lines that install your .desktop and appdata files and replace them with the following:
 
-   ```text
+   ```coffeescript
    #Translate and install our .desktop file
    i18n.merge_file(
-       input: join_paths('data', 'hello-again.desktop.in'),
+       input: 'data' / 'hello-again.desktop.in',
        output: meson.project_name() + '.desktop',
-       po_dir: join_paths(meson.source_root(), 'po'),
+       po_dir: meson.source_root() / 'po',
        type: 'desktop',
        install: true,
-       install_dir: join_paths(get_option('datadir'), 'applications')
+       install_dir: get_option('datadir') / 'applications'
    )
 
    #Translate and install our .appdata file
    i18n.merge_file(
-       input: join_paths('data', 'hello-again.appdata.xml.in'),
+       input: 'data' / 'hello-again.appdata.xml.in',
        output: meson.project_name() + '.appdata.xml',
-       po_dir: join_paths(meson.source_root(), 'po'),
+       po_dir: meson.source_root() / 'po',
        install: true,
-       install_dir: join_paths(get_option('datadir'), 'metainfo')
+       install_dir: get_option('datadir') / 'metainfo'
    )
    ```
 
@@ -51,7 +51,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
 
 3. Still in this file, add the following as the last line:
 
-   ```text
+   ```coffeescript
    subdir('po')
    ```
 
@@ -66,7 +66,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
 
 5. Now, Create a directory named "po" in the root folder of your project. Inside of your po directory you will need to create another "meson.build" file. This time, its contents will be:
 
-   ```text
+   ```coffeescript
     i18n.gettext(meson.project_name(),
         args: '--directory=' + meson.source_root(),
         preset: 'glib'


### PR DESCRIPTION
Fixes #86 

Intentionally doesn't touch the icons part to avoid conflicts with #84 

While we're here, claim that meson is "coffeescript" instead of "text" so we get approximate syntax highlighting. Also, Meson syntax is no spaces before ()