### PR TITLE
Add copy about uninstalling the application

### DIFF
--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -69,6 +69,14 @@ If all went well, you should now be able to open your app from the Applications 
 If you were about to add the "build" folder to your git repository and push it, stop! This binary was built for your computer and we don't want to redistribute it. In fact, we built your app in a separate folder like this so that we can easily delete or ignore the "build" folder and it won't mess up our app's source code.
 {% endhint %}
 
+## Uninstalling the application
+
+To uninstall your application, we need to remove the several files we've created outside of our project folder:
+
+* Binary file located at `/usr/bin/com.github.yourusername.hello-again`
+* Desktop file in `/usr/share/applications/com.github.yourusername.hello-again.desktop`
+* Application Data file in `/usr/share/metainfo/com.github.yourusername.hello-again.appdata.xml`
+
 ## Review
 
 Let's review all we've learned to do:
@@ -78,6 +86,7 @@ Let's review all we've learned to do:
 * License our app under the GPL and declare our app's authors in a standardized manner
 * Create a .desktop file using RDNN that tells the computer how to display our app in the Applications Menu and the Dock
 * Set up a Meson build system that contains all the rules for building our app and installing it cleanly
+* Uninstall our application cleanly
 
 That's a lot! You're well on your way to becoming a bona fide app developer for elementary OS. Give yourself a pat on the back, then take some time to play around with this example. Change the names of files and see if you can still build and install them properly. Ask another developer to clone your repo from GitHub and see if it builds and installs cleanly on their computer. If so, you've just distributed your first app! When you're ready, we'll move onto the next section: Translations.
 

--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -77,6 +77,12 @@ To uninstall your application, we need to remove the several files we've created
 * Desktop file in `/usr/share/applications/com.github.yourusername.hello-again.desktop`
 * Application Data file in `/usr/share/metainfo/com.github.yourusername.hello-again.appdata.xml`
 
+```bash
+sudo rm /usr/bin/com.github.yourusername.hello-again
+sudo rm /usr/share/applications/com.github.yourusername.hello-again.desktop
+sudo rm /usr/share/metainfo/com.github.yourusername.hello-again.appdata.xml
+```
+
 ## Review
 
 Let's review all we've learned to do:


### PR DESCRIPTION
I've attempted to add some copy about uninstalling the application to address issue https://github.com/elementary/docs/issues/97.

I've compiled what I believe uninstalls the application, but I am following the tutorial while proposing these edits.  So if one of the maintainers would advise/edit as needed, I'd be happy to update my branch.

-----

### Uninstalling the application

To uninstall your application, we need to remove the several files we've created outside of our project folder:

* Binary file located at /usr/bin/com.github.yourusername.hello-again
* Desktop file in /usr/share/applications/com.github.yourusername.hello-again.desktop
* Application Data file in /usr/share/metainfo/com.github.yourusername.hello-again.appdata.xml

```bash
sudo rm /usr/bin/com.github.yourusername.hello-again
sudo rm /usr/share/applications/com.github.yourusername.hello-again.desktop
sudo rm /usr/share/metainfo/com.github.yourusername.hello-again.appdata.xml
```