### PR TITLE
Add missing socket to flatpak manifest to allow app to start

### DIFF
--- a/writing-apps/our-first-app/packaging.md
+++ b/writing-apps/our-first-app/packaging.md
@@ -40,6 +40,7 @@ finish-args:
   - '--share=ipc'
   - '--socket=fallback-x11'
   - '--socket=wayland'
+  - '--socket=session-bus'
 
 # This section is where you list all the source code required to build your app.
 # If we had external dependencies that weren't included in our SDK, we would list


### PR DESCRIPTION
This PR adds a missing socket to address the issue in https://github.com/elementary/docs/issues/120 where the flatpak application installs (builds, installs, creates desktop entry), but doesn't start.

The missing line is `- '--socket=session-bus'`.