### PR TITLE
Closes #147: provide reason why string templates shouldn’t be used

### DIFF
--- a/writing-apps/code-style.md
+++ b/writing-apps/code-style.md
@@ -310,7 +310,7 @@ print ("Hello World");
 
 ## String Formatting
 
-Avoid using literals when formatting strings:
+Avoid using literals when formatting strings, as they cannot be [localized](https://wiki.gnome.org/TranslationProject/DevGuidelines):
 
 ```csharp
 var string = @"Error parsing config: $(config_path)";


### PR DESCRIPTION
Specifically, because they cannot be localised.