### PR TITLE
Normalize syntax highlighting

### DIFF
--- a/apis/actions.md
+++ b/apis/actions.md
@@ -10,7 +10,7 @@ GTK and GLib have a powerful API called [`GLib.Action`](https://valadoc.org/gio-
 
 Begin by creating a `Gtk.Application` with a `Gtk.ApplicationWindow` as you've done in previous examples. Once you have that set up, let's create a new [`Gtk.HeaderBar`](https://valadoc.org/gtk+-3.0/Gtk.HeaderBar.html). Typically your app will have a HeaderBar, at the top of the window, which will contain tool items that users will interact with to trigger your app's actions.
 
-```text
+```vala
 protected override void activate () {
     var header_bar = new Gtk.HeaderBar () {
         show_close_button = true
@@ -30,7 +30,7 @@ Since we're using this HeaderBar as our app's main titlebar, we need to set `sho
 
 Now, still in the activate function, let's create a new [`Gtk.Button`](https://valadoc.org/gtk+-3.0/Gtk.Button.html) with a big colorful icon and add it to our headerbar:
 
-```text
+```vala
 protected override void activate () {
     var button = new Gtk.Button.from_icon_name ("process-stop", Gtk.IconSize.LARGE_TOOLBAR);
 
@@ -53,7 +53,7 @@ If you compile your app, you can see that it now has a custom HeaderBar with a b
 
 Let's define a new Quit action by adding the following to the beginning of the `activate ()` method
 
-```text
+```vala
 var quit_action = new SimpleAction ("quit", null);
 
 add_action (quit_action);
@@ -62,7 +62,7 @@ set_accels_for_action ("app.quit",  {"<Control>q", "<Control>w"});
 
 and this to the end of the `activate ()` method:
 
-```text
+```vala
 quit_action.activate.connect (() => {
     main_window.destroy ();
 });
@@ -77,7 +77,7 @@ You'll notice that we do a few things here:
 
 and now we can tie the action to the HeaderBar Button by assigning the `action_name` property of our Button:
 
-```text
+```vala
 var button = new Gtk.Button.from_icon_name ("process-stop", Gtk.IconSize.LARGE_TOOLBAR) {
     action_name = "app.quit"
 };
@@ -95,7 +95,7 @@ There's one more thing we can do here to help improve your app's usability. You 
 
 First, make sure you've included Granite in the build dependencies declared in your meson.build file:
 
-```text
+```coffeescript
 executable(
     meson.project_name(),
     'src/Application.vala',
@@ -109,7 +109,7 @@ executable(
 
 Then, set the `tooltip_markup` property of your HeaderBar Button:
 
-```text
+```vala
 var button = new Gtk.Button.from_icon_name ("process-stop", Gtk.IconSize.LARGE_TOOLBAR) {
     action_name = "app.quit",
     tooltip_markup = Granite.markup_accel_tooltip (
@@ -126,4 +126,3 @@ Compile your app one last time and hover over the HeaderBar Button to see its de
 {% hint style="info" %}
 If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/glib-action)
 {% endhint %}
-

--- a/apis/color-scheme.md
+++ b/apis/color-scheme.md
@@ -12,7 +12,7 @@ elementary OS ships with two styles for app widgets: a dark style and a light st
 
 Some apps, like photo or video editors, benefit from reducing the contrast between their content and the app's UI by always choosing to be displayed using a dark style. You can set the dark style for your app by using `Gtk.Settings` and setting the property `gtk_application_prefer_dark_theme`. In your Application class, add the following lines to your `activate` function:
 
-```csharp
+```vala
 protected override void activate () {
     var gtk_settings = Gtk.Settings.get_default ();
     gtk_settings.gtk_application_prefer_dark_theme = true;
@@ -27,7 +27,7 @@ Many apps will be usable in either a light or dark style. In this case, apps sho
 
 First, make sure you've included Granite in the build dependencies declared in your meson.build file:
 
-```text
+```coffeescript
 executable(
     meson.project_name(),
     'src/Application.vala',
@@ -41,7 +41,7 @@ executable(
 
 Now, you can read and respond to the user's style preference with `Granite.Settings` and then use `Gtk.Settings` to set it in your app's `activate` function.
 
-```csharp
+```vala
 protected override void activate () {
     // First we get the default instances for Granite.Settings and Gtk.Settings
     var granite_settings = Granite.Settings.get_default ();
@@ -56,4 +56,3 @@ protected override void activate () {
     });
 }
 ```
-

--- a/apis/gresource.md
+++ b/apis/gresource.md
@@ -4,7 +4,7 @@ You can include additional resources with your app like icons or CSS files using
 
 In the `data` directory, create a new file called `gresource.xml` with the following contents:
 
-```markup
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/yourusername/yourrepositoryname">
@@ -48,7 +48,7 @@ Now that we have a `gresource.xml` file and have included it in the build system
 
 As we saw in the section on [`GLib.Action`](actions.md), GTK has a baked-in set of icon sizes defined under the namespace [`Gtk.IconSize`](https://valadoc.org/gtk+-3.0/Gtk.IconSize.html). When creating icons, it is important to know which of these sizes will be used and to design and hint the icon at that size. For more information about creating and hinting icons, check out the [Human Interface Guidelines](https://docs.elementary.io/hig/reference/iconography#size). Add your custom icon to the `data` directory, and then update your `gresource.xml` file to reference it:
 
-```markup
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/yourusername/yourrepositoryname">
@@ -59,7 +59,7 @@ As we saw in the section on [`GLib.Action`](actions.md), GTK has a baked-in set 
 
 If you want to use the same icon name in multiple sizes in your app, you can `alias` the icon to paths in [hicolor](https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html) and GTK will automatically load the correct version when its size is referenced:
 
-```markup
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/yourusername/yourrepositoryname">
@@ -73,7 +73,7 @@ If you want to use the same icon name in multiple sizes in your app, you can `al
 
 Now we can add the GResource path to the system's built-in icon theme in the `Application` class' `activate ()` function. This will let us reference the icon name without using long paths, and automatically handle icon sizing as previously mentioned Again, don't forget to use the same RDNN'd path that was defined in `gresource.xml`:
 
-```csharp
+```vala
 protected override void activate () {
     Gtk.IconTheme.get_default ().add_resource_path ("com/github/yourusername/yourrepositoryname");
 
@@ -84,7 +84,7 @@ protected override void activate () {
 
 The last step is to create a `Gtk.Image` or `Gtk.Button` using your custom icon and add it to the main window:
 
-```csharp
+```vala
 protected override void activate () {
     Gtk.IconTheme.get_default ().add_resource_path ("/com/github/yourusername/yourrepositoryname");
 
@@ -104,4 +104,3 @@ protected override void activate () {
     main_window.show_all ();
 }
 ```
-

--- a/apis/launchers.md
+++ b/apis/launchers.md
@@ -10,16 +10,16 @@ For this integration you can use the [Granite.Services.Application API](https://
 
 ### Current API support:
 
-| Service | Badge Counter | Progress Bar | Actions |
-| :--- | :--- | :--- | :--- |
-| Applications Menu | ✔️ Yes | ✖️ No | ✔️ Yes |
-| Dock | ✔️ Yes | ✔️ Yes | ✔️ Yes |
+| Service           | Badge Counter | Progress Bar | Actions |
+| :---------------- | :------------ | :----------- | :------ |
+| Applications Menu | ✔️ Yes        | ✖️ No        | ✔️ Yes  |
+| Dock              | ✔️ Yes        | ✔️ Yes       | ✔️ Yes  |
 
 ## Setting Up
 
 Before writing any code, you must add the library Granite to your build system. We already installed this library during [The Basic Setup](../writing-apps/the-basic-setup.md) when we installed `elementary-sdk`. Open your meson.build file and add the new dependency to the `executable` method.
 
-```text
+```coffeescript
 executable(
     meson.project_name(),
     'src/Application.vala',
@@ -41,7 +41,7 @@ Once you've set up `granite` in your build system and created a new `Gtk.Applica
 
 Showing a badge in the dock and Applications Menu with the number `12` can be done with the following lines:
 
-```text
+```vala
 Granite.Services.Application.set_badge_visible.begin (true);
 Granite.Services.Application.set_badge.begin (12);
 ```
@@ -52,7 +52,7 @@ Keep in mind you have to set the `set_badge_visible` property to true, and use a
 
 The same goes for showing a progress bar, here we show a progress bar showing 20% progress:
 
-```text
+```vala
 Granite.Services.Application.set_progress_visible.begin (true);
 Granite.Services.Application.set_progress.begin (0.2f);
 ```
@@ -67,7 +67,7 @@ Adding actions to a `.desktop` file does not involve writing any code or using a
 
 Actions must first be declared in a new `Actions` line in your app's .desktop file. This line should contain a `;` separated list of unique action names:
 
-```text
+```ini
 [Desktop Entry]
 Name=Hello Again
 [...]
@@ -76,7 +76,7 @@ Actions=ActionID;
 
 Then below, add the action itself using the same unique ID:
 
-```text
+```ini
 [Desktop Action ActionID]
 Name=The name of the action
 Icon=com.github.myteam.myapp.action-id
@@ -91,7 +91,7 @@ The action name should not include your app's name, as it will always be display
 
 Let's take a look at an example of an action that opens a new window of an app:
 
-```text
+```ini
 [Desktop Entry]
 Name=App Name
 Exec=com.github.yourusername.yourrepositoryname
@@ -106,4 +106,3 @@ Exec=com.github.yourusername.yourrepositoryname -n
 Note that just adding `-n` or any other argument will not automatically make your app open a new window; your app must handle and interpret command line arguments. The [GLib.Application API](https://valadoc.org/gio-2.0/GLib.Application.html) provides many examples and an extensive documentation on how to handle these arguments, particularly the [command\_line signal](https://valadoc.org/gio-2.0/GLib.Application.command_line.html).
 
 See the [freedesktop.org Additional applications actions section](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s10.html) for a detailed description of what keys are supported and what they do.
-

--- a/apis/notifications.md
+++ b/apis/notifications.md
@@ -29,7 +29,7 @@ Now that we have an empty window, let's use what we learned in [creating layouts
 
 In between `var main_window...` and `main_window.show ();`, write the following lines of code:
 
-```csharp
+```vala
 var title_label = new Gtk.Label (_("Notifications"));
 var show_button = new Gtk.Button.with_label (_("Show"));
 
@@ -49,7 +49,7 @@ Since we're adding translatable strings, don't forget to update your translation
 
 Now that we have a Gtk.Application we can send notifications. Let's connect a function to the button we created and use it to send a notification:
 
-```csharp
+```vala
 show_button.clicked.connect (() => {
     var notification = new Notification (_("Hello World"));
     notification.set_body (_("This is my first notification!"));
@@ -66,7 +66,7 @@ Okay, now compile your new app. if everything works, you should see your new app
 
 Notifications will automatically contain your app's icon, but you can add additional context by setting a badge icon. Right after the line containing `var notification = New Notification`, add:
 
-```csharp
+```vala
 notification.set_icon (new ThemedIcon ("process-completed"));
 ```
 
@@ -86,7 +86,7 @@ You can browse the full set of named icons using the app [LookBook](http://appce
 
 You can also add buttons to notifications that will trigger actions defined in the `app` namespace. To add a button, first define an action in your Application class as we did in [the actions section](actions.md).
 
-```csharp
+```vala
 var quit_action = new SimpleAction ("quit", null);
 
 add_action (quit_action);
@@ -98,7 +98,7 @@ quit_action.activate.connect (() => {
 
 Now, we can add a button to the notification with a translatable label and the action ID.
 
-```csharp
+```vala
 notification.add_button (_("Quit"), "app.quit");
 ```
 
@@ -112,7 +112,7 @@ Remember that `SimpleAction`s added in the `Application` class with `add_action 
 
 Notifications also have priority. When a notification is set as `URGENT` it will stay on the screen until either the user interacts with it, or you withdraw it. To make an urgent notification, add the following line before the `send_notification ()` function
 
-```csharp
+```vala
 notification.set_priority (NotificationPriority.URGENT);
 ```
 
@@ -124,7 +124,7 @@ We now know how to send a notification, but what if you need to update it with n
 
 Let's make the replace button. This button will replace the current notification with one with different information. Let's create a new button for it, and add it to the grid:
 
-```csharp
+```vala
 var replace_button = new Gtk.Button.with_label (_("Replace"));
 
 grid.add (replace_button);
@@ -154,4 +154,3 @@ Let's review what all we've learned:
 * We can replace outdated notifications by setting a replaces ID
 
 As you can see, notifications have a number of advanced features and can automatically inherit some information from `Gtk.Application`. If you need some further reading on notifications, Check out the page about `Glib.Notification` on [Valadoc](https://valadoc.org/gio-2.0/GLib.Notification).
-

--- a/apis/state-saving.md
+++ b/apis/state-saving.md
@@ -8,7 +8,7 @@ For the simplest example, let's create a switch in your app, and save its state.
 
 First, you need to define what settings your app will use so they can be accessed by your app. In your `data/` folder, create a new file named `gschema.xml`. Inside it, let's define a key for the switch:
 
-```markup
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema path="/com/github/yourusername/yourrepositoryname/" id="com.github.yourusername.yourrepositoryname">
@@ -27,7 +27,7 @@ The schema's `path` and `id` attributes are your app's ID \(`path` in a `/` form
 
 In order to interact with the settings key we just defined, we need to create a GLib.Settings object in our application. Building on previous examples, you can create a Gtk.Switch, add it to your window, create a GLib.Settings object, and bind the switch to a settings key like so:
 
-```csharp
+```vala
 protected override void activate () {
     var switch = new Gtk.Switch () {
         halign = Gtk.Align.CENTER,
@@ -96,4 +96,3 @@ To see the state saving functionality in action, you can open your app, toggle t
 {% hint style="info" %}
 If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/gsettings)
 {% endhint %}
-

--- a/appcenter/markdown-badges.md
+++ b/appcenter/markdown-badges.md
@@ -6,13 +6,13 @@ elementary provides badges, e.g. for your GitHub README. Badges will open to you
 
 ## Markdown
 
-```text
+```markdown
 [![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.USER.REPO)
 ```
 
 ## HTML
 
-```markup
+```html
 <a href="https://appcenter.elementary.io/com.github.USER.REPO"><img src="https://appcenter.elementary.io/badge.svg" alt="Get it on AppCenter"></a>
 ```
 

--- a/writing-apps/code-style/README.md
+++ b/writing-apps/code-style/README.md
@@ -10,7 +10,7 @@ Internally, elementary uses the following code style guide to ensure that code i
 
 White space comes before opening parentheses or braces:
 
-```csharp
+```vala
 public string get_text () {}
 if (a == 5) {
     return 4;
@@ -23,7 +23,7 @@ var my_instance = new Object ();
 
 An exception is admitted for Gettext-localized strings, where no space should go between the underscore and the opening parenthese:
 
-```csharp
+```vala
 // Space before parentheses since it's normal method:
 button.label = set_label_string ();
 // No space before parentheses since it's gettext-localized string:
@@ -32,13 +32,13 @@ button.tooltip_text = _("Download");
 
 Whitespace goes between numbers and operators in all math-related code.
 
-```csharp
+```vala
 c = (n * 2) + 4;
 ```
 
 Lines consisting of closing brackets \(`}` or `)`\) should be followed by an empty line, except when followed by another closing bracket or an `else` statement.
 
-```csharp
+```vala
 if (condition) {
     // ...
 } else {
@@ -56,7 +56,7 @@ Vala code is indented using 4 spaces for consistency and readability.
 
 In classes, functions, loops and general flow control, the first brace is on the end of the first line \("One True Brace Style"\), followed by the indented code, and a line closing the function with a brace:
 
-```csharp
+```vala
 public int my_function (int a, string b, long c, int d, int e) {
     if (a == 5) {
         b = 3;
@@ -70,7 +70,7 @@ public int my_function (int a, string b, long c, int d, int e) {
 
 On conditionals and loops, always use braces even if there's only one line of code:
 
-```csharp
+```vala
 if (my_var > 2) {
     print ("hello\n");
 }
@@ -78,7 +78,7 @@ if (my_var > 2) {
 
 Cuddled else and else if:
 
-```csharp
+```vala
 if (a == 4) {
     b = 1;
     print ("Yay");
@@ -90,7 +90,7 @@ if (a == 4) {
 
 If you are checking the same variable more than twice, use switch/case instead of multiple else/if:
 
-```csharp
+```vala
 switch (week_day) {
    case "Monday":
        message ("Let's work!");
@@ -109,7 +109,7 @@ switch (week_day) {
 
 Markup languages like HTML, XML, and YML should use two-space indentation since they are much more verbose and likely to hit line-length issues sooner.
 
-```markup
+```xml
 <component type="desktop">
   <name>Calendar</name>
   <description>
@@ -144,7 +144,7 @@ Comments are either on the same line as the code they reference or in a special 
 
 Comments are indented alongside the code, and obvious comments do more harm than good.
 
-```csharp
+```vala
 /* User chose number five */
 if (c == 5) {
     a = 3;
@@ -155,7 +155,7 @@ if (c == 5) {
 
 Sometimes detailed descriptions in the context of translatable strings are necessary for disambiguation or to help in the creation of accurate translations. For these situations use `/// TRANSLATORS:` comments.
 
-```csharp
+```vala
 /// TRANSLATORS: The first %s is search term, the second is the name of default browser
 title = _("Search for %s in %s").printf (query, get_default_browser_name ());
 ```
@@ -164,7 +164,7 @@ title = _("Search for %s in %s").printf (query, get_default_browser_name ());
 
 Variable and function names are all lower case and separated by underscores:
 
-```csharp
+```vala
 var my_variable = 5;
 
 public void my_function_name () {
@@ -174,7 +174,7 @@ public void my_function_name () {
 
 Classes and enums are Upper Camel Case \(aka Pascal Case\):
 
-```csharp
+```vala
 public class UserListBox : Gtk.ListBox {
     private enum OperatingSystem {
         ELEMENTARY_OS,
@@ -185,7 +185,7 @@ public class UserListBox : Gtk.ListBox {
 
 Constants and enum members should be all uppercase and separated by underscores:
 
-```csharp
+```vala
 public const string UBUNTU = "ubuntu";
 
 private enum OperatingSystem {
@@ -196,7 +196,7 @@ private enum OperatingSystem {
 
 The values of constant strings \(such as when used with GLib.Action\) should be lowercase and separated with dashes:
 
-```csharp
+```vala
 public const string ACTION_GO_BACK = "action-go-back";
 ```
 
@@ -204,7 +204,7 @@ public const string ACTION_GO_BACK = "action-go-back";
 
 Avoid using `as` keyword when casting as it might give `null` as result, which could be forgotten to check.
 
-```csharp
+```vala
 /* OK */
 ((Gtk.Entry) widget).max_width_chars
 
@@ -218,13 +218,13 @@ In places or operations where you would otherwise use `get` or `set` , you shoul
 
 For example, instead of using
 
-```csharp
+```vala
 set_can_focus (false);
 ```
 
 you should use
 
-```csharp
+```vala
 can_focus = false;
 ```
 
@@ -232,7 +232,7 @@ can_focus = false;
 
 This is especially clearer when initializing an object with many properties. Avoid the following
 
-```text
+```vala
 var label = new Gtk.Label ("Test Label");
 label.set_ellipsize (Pango.EllipsizeMode.END);
 label.set_valign (Gtk.Align.END);
@@ -242,7 +242,7 @@ label.set_xalign (0);
 
 and instead do this
 
-```text
+```vala
 var label = new Gtk.Label ("Test Label") {
     ellipsize = Pango.EllipsizeMode.END,
     valign = Gtk.Align.END,
@@ -255,7 +255,7 @@ var label = new Gtk.Label ("Test Label") {
 
 This goes for creating methods inside of classes as well. Instead of
 
-```csharp
+```vala
 private int _number;
 
 public int get_number () {
@@ -269,13 +269,13 @@ public void set_number (int value) {
 
 you should use
 
-```csharp
+```vala
 public int number { get; set; }
 ```
 
 or, where you need some extra logic in the getters and setters:
 
-```csharp
+```vala
 private int _number;
 public int number {
     get {
@@ -298,13 +298,13 @@ Preferring properties in classes enables the use of [`GLib.Object.bind_property 
 
 Referring to GLib is not necessary. If you want to print something instead of:
 
-```csharp
+```vala
 GLib.print ("Hello World");
 ```
 
 You can use
 
-```csharp
+```vala
 print ("Hello World");
 ```
 
@@ -312,19 +312,19 @@ print ("Hello World");
 
 Avoid using literals when formatting strings:
 
-```csharp
+```vala
 var string = @"Error parsing config: $(config_path)";
 ```
 
 Instead, prefer printf style placeholders:
 
-```csharp
+```vala
 var string = "Error parsing config: %s".printf (config_path);
 ```
 
 Warnings in Vala use printf syntax by default:
 
-```csharp
+```vala
 critical ("Error parsing config: %s", config_path);
 ```
 
@@ -340,7 +340,7 @@ Ideally, lines should have no more than 80 characters per line, because this is 
 
 For methods that take multiple arguments, it is not uncommon to have very long line lengths. In this case, treat parenthesis like brackets and split lines at commas like so:
 
-```text
+```vala
 var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
     "Basic Information and a Suggestion",
     "Further details, including information that explains any unobvious consequences of actions.",
@@ -353,7 +353,7 @@ var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
 
 If you are using elementary Code or your code editor supports [EditorConfig](https://editorconfig.org/), you can use this as a default `.editorconfig` file in your projects:
 
-```text
+```ini
 # EditorConfig <https://EditorConfig.org>
 root = true
 
@@ -371,4 +371,3 @@ tab_width = 4
 [{*.html,*.xml,*.xml.in,*.yml}]
 tab_width = 2
 ```
-

--- a/writing-apps/code-style/class-construction.md
+++ b/writing-apps/code-style/class-construction.md
@@ -4,7 +4,7 @@ When creating a new class, prefer GObject-style construction. This type of class
 
 A simple class written with GObject-style construction looks like this:
 
-```csharp
+```vala
 public class MyClass : Object {
     public int foo { get; construct; }
 
@@ -24,17 +24,17 @@ public class MyClass : Object {
 
 ## Construction Properties
 
-```csharp
+```vala
 public int foo { get; construct; }
 ```
 
-In the above example, `MyClass` has a `public` property `foo` whose type is `int`, but we've also declared it as `{ get; construct; }`. This shorthand declares the type of access for this property's `get` and `set` functions. Since we declared the property as `public`, `get` is also public, but we've declared the `set` function as `construct`, which means we can only assign its value as a constructor argument. 
+In the above example, `MyClass` has a `public` property `foo` whose type is `int`, but we've also declared it as `{ get; construct; }`. This shorthand declares the type of access for this property's `get` and `set` functions. Since we declared the property as `public`, `get` is also public, but we've declared the `set` function as `construct`, which means we can only assign its value as a constructor argument.
 
 We want construction arguments to be public to ensure that we can later get information out of a class that was used to construct it, if need be. But it's important to declare limited `set` access on properties for future maintainability. Since there is no handling for changes in this property in the `construct` block, setting this property after the class is constructed would have no effect, even if we allowed it by declaring `{ get; construct set; }`.
 
 ## Constructors
 
-```csharp
+```vala
 public MyClass (int foo) {
     Object (foo: foo);
 }
@@ -42,12 +42,11 @@ public MyClass (int foo) {
 
 `MyClass` also contains a constructor; it describes what arguments are required to construct the class. We've declared here that in order to construct `MyClass`, we need an `int` passed in when we initialize a new object such as with `var new_class = new MyClass (5);`
 
-
 Inside the constructor, we have a special `Object ()` call, in which we specify a property and its value, `Object (foo: foo);`. This sets the value of the integer property `foo` defined earlier to the value received as an argument. It is equivalent to saying `this.foo = foo;`.
 
 ## The Construct Block
 
-```csharp
+```vala
 construct {
     if (foo) {
         // Do stuff
@@ -61,7 +60,7 @@ When using GObject-style construction, a constructor should only contain code th
 
 ## Declaring Multiple Constructors
 
-```csharp
+```vala
 public class Row : Object {
     public string name { get; construct; }
     public Icon icon { get; construct; }
@@ -92,7 +91,7 @@ To see how this style of class construction scales and keeps code organized, let
 - a default constructor that takes two arguments: `string name` and `Icon icon`
 - a separate, named constructor which takes one argument: a `Device` object
 
-```csharp
+```vala
 public Row (string name, Icon icon) {
     Object (
         name: name,
@@ -110,7 +109,7 @@ public Row.from_device (Device device) {
 
 Note that in both cases, we handle the arguments in the constructor, while the actual logic of creating UI widgets lives in the common `construct` block.
 
-```csharp
+```vala
 construct {
     var icon = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DND);
     var label = new Gtk.Label (name);

--- a/writing-apps/creating-layouts.md
+++ b/writing-apps/creating-layouts.md
@@ -14,7 +14,7 @@ Now that we’ve gotten that out of the way, let’s get back to our Window and 
 
 Just like when we add a Button or Label, we need to create our `Gtk.Grid`. As always, don’t copy and paste! Practice makes perfect. We create a new Gtk.Grid like this:
 
-```csharp
+```vala
 var grid = new Gtk.Grid () {
     orientation = Gtk.Orientation.VERTICAL
 };
@@ -24,14 +24,14 @@ Remember that Button and Label accepted an argument \(a String\) in the creation
 
 Let’s add some stuff to the Grid:
 
-```csharp
+```vala
 grid.add (new Gtk.Label (_("Label 1")));
 grid.add (new Gtk.Label (_("Label 2")));
 ```
 
 We can add the grid to our window using the same method that we just used to add widgets to our grid:
 
-```csharp
+```vala
 main_window.add (grid);
 ```
 
@@ -43,7 +43,7 @@ Okay, so you know all about using a `Gtk.Grid` to pack multiple children into a 
 
 Let’s create a Window with a vertical Grid that contains a Button and a Label:
 
-```csharp
+```vala
 var button = new Gtk.Button.with_label (_("Click me!"));
 
 var label = new Gtk.Label (null);
@@ -62,7 +62,7 @@ This time when we created our grid, we gave it another property: `row_spacing`. 
 
 Now, let’s hook up the button to change that label. To keep our code logically separated, we’re going to add it below `main_window.add (grid);`. In this way, the first portion of our code defines the UI and the next portion defines the functions that we associated with the UI:
 
-```csharp
+```vala
 button.clicked.connect (() => {
     label.label = _("Hello World!");
     button.sensitive = false;
@@ -75,7 +75,7 @@ Remember, we set the button as insensitive here because clicking it again has no
 
 While we can use `Gtk.Grid` to create single row or single column layouts with the add method, we can also use it to create row-and-column-based layouts with the `attach` method. First we’re going to create all the widgets we want to attach to our grid, then we’ll create a new `Gtk.Grid` and set both column and row spacing, and finally we’ll attach our widgets to the grid.
 
-```csharp
+```vala
 var hello_button = new Gtk.Button.with_label (_("Say Hello"));
 var hello_label = new Gtk.Label (null);
 
@@ -90,7 +90,7 @@ var grid = new Gtk.Grid () {
 
 Make sure to give the Grid, Buttons, and Labels unique names that you’ll remember. It’s best practice to use descriptive names so that people who are unfamiliar with your code can understand what a widget is for without having to know your app inside and out.
 
-```csharp
+```vala
 // add first row of widgets
 grid.attach (hello_button, 0, 0, 1, 1);
 grid.attach_next_to (hello_label, hello_button, Gtk.PositionType.RIGHT, 1, 1);
@@ -114,7 +114,7 @@ You can also use `attach_next_to` to place a widget next to another one on [all 
 
 Don’t forget to add the functionality associated with our buttons:
 
-```csharp
+```vala
 hello_button.clicked.connect (() => {
     hello_label.label = _("Hello World!");
     hello_button.sensitive = false;
@@ -139,4 +139,3 @@ Let’s recap what we learned in this section:
 * We added multiple widgets into a single Gtk.Grid using the attach method to create complex layouts containing Buttons and Labels that did cool stuff.
 
 Now that you understand more about Gtk, Grids, and using Buttons to alter the properties of other widgets, try packing other kinds of widgets into a window like a Toolbar and changing other properties of [Labels](https://valadoc.org/gtk+-3.0/Gtk.Label) like `width_chars` and `ellipsize`. Don’t forget to play around with the attach method and widgets that span across multiple rows and columns. Remember that Valadoc is super helpful for learning more about the methods and properties associated with widgets.
-

--- a/writing-apps/hello-world.md
+++ b/writing-apps/hello-world.md
@@ -19,7 +19,7 @@ Create a new file in Code and save it as "Application.vala" inside your "src" fo
 
 In this file, we're going to create a special class called a `Gtk.Application`. `Gtk.Application` is a class that handles many important aspects of a Gtk app like uniqueness and the ID you need to identify your app to the notifications server. If you want some more details about `Gtk.Application`, [check out Valadoc](https://valadoc.org/gtk+-3.0/Gtk.Application). For now, type the following in "Application.vala".
 
-```text
+```vala
 public class MyApp : Gtk.Application {
     public MyApp () {
         Object (
@@ -56,7 +56,7 @@ Do you see a new, empty window called "Hello World"? If so, congratulations! If 
 
 Now that we've defined a nice window, let's put a button inside of it. Add the following to your application at the beginning of the `activate ()` function:
 
-```text
+```vala
 var button_hello = new Gtk.Button.with_label ("Click me!") {
     margin = 12
 };
@@ -69,7 +69,7 @@ button_hello.clicked.connect (() => {
 
 Then add this line right before `main_window.show_all ()`:
 
-```csharp
+```vala
 main_window.add (button_hello);
 ```
 
@@ -130,4 +130,3 @@ Feel free to play around with this example. Make the window a different size, se
 Remember how when we compiled our code, we used the `valac` command and the argument `--pkg gtk+-3.0`? What we did there was make use of a "library". If you're not familiar with the idea of libraries, a library is a collection of methods that your program can use. So this argument tells `valac` to include the GTK+ library \(version 3.0\) when compiling our app.
 
 In our code, we've used the `Gtk` "Namespace" to declare that we want to use methods from GTK \(specifically, `Gtk.Window` and `Gtk.Button.with_label`\). Notice that there is a hierarchy at play. If you want to explore that hierarchy in more detail, you can [check out Valadoc](https://valadoc.org/gtk+-3.0/Gtk.Button).
-

--- a/writing-apps/logging.md
+++ b/writing-apps/logging.md
@@ -12,7 +12,7 @@ Debug logs usually give detailed information on the flow through the system and 
 
 Log functions, like `debug` use [`printf`](http://www.cplusplus.com/reference/cstdio/printf/) style formatting and can be called like this:
 
-```text
+```vala
 string name = "Bob";
 int age = 30;
 debug ("Person: %s %i", name, age);
@@ -26,7 +26,7 @@ Start your app with `G_MESSAGES_DEBUG=all` to print debug messages
 
 Use info log level to log informational messages as well as interesting runtime events. These logs are also immediately visible on a status console, and should be kept to a minimum.
 
-```text
+```vala
 info ("An event occured");
 ```
 
@@ -34,7 +34,7 @@ info ("An event occured");
 
 Use the message log level to output a message.
 
-```text
+```vala
 message ("An event occured");
 ```
 
@@ -42,7 +42,7 @@ message ("An event occured");
 
 The warning log level outputs messages that warn of, for example, use of deprecated APIs, 'almost' errors, or runtime situations that are undesirable or unexpected, but not necessarily "wrong". These logs are immediately visible on a status console.
 
-```text
+```vala
 warning ("Something potentially problematic happened!");
 ```
 
@@ -54,7 +54,7 @@ Start your app with `G_DEBUG=fatal-warnings` to exit the program at the first ca
 
 Critical log level is used when there is a severe application failure that should be investigated immediately.
 
-```text
+```vala
 critical ("A major issue occured! Uh oh!");
 ```
 
@@ -66,7 +66,6 @@ Start your app with `G_DEBUG=fatal-criticals` to exit the program at the first c
 
 Error log level includes logs for runtime errors or unexpected conditions. These errors are immediately visible on a status console and cause your app to exit.
 
-```text
+```vala
 error ("Some catastrophic happened and the app had to exit!");
 ```
-

--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -9,7 +9,7 @@ To create our first real app, we're going to need all the old stuff that we used
 1. Create a new folder inside "~/Projects" called "hello-again".Then, go into "hello-again" and create our directory structure including the "src" folder.
 2. Create "Application.vala" in the "src" folder. This time we're going to prefix our file with a small legal header. Make sure this header matches the license of your code and assigns copyright to you. More info about this later.
 
-   ```csharp
+   ```vala
    /*
     * SPDX-License-Identifier: GPL-3.0-or-later
     * SPDX-FileCopyrightText: 2021 Your Name <you@email.com>
@@ -19,13 +19,13 @@ To create our first real app, we're going to need all the old stuff that we used
 3. Now, let's create a `Gtk.Application`, a `Gtk.ApplicationWindow`, and set the window's default properties. Refer back to the last chapter if you need a refresher.
 4. For the sake of time let's just put a `Gtk.Label` instead of a `Gtk.Button`. We don't need to try to make the label do anything when you click it.
 
-   ```csharp
+   ```vala
    var label = new Gtk.Label ("Hello Again World!");
    ```
 
    Don't forget to add it to your window and show the window's contents:
 
-   ```csharp
+   ```vala
    main_window.add (label);
    main_window.show_all ();
    ```
@@ -48,7 +48,7 @@ Every app comes with a .desktop file. This file contains all the information nee
 2. Create a new file in Code and save it in the "data" folder as "hello-again.desktop".
 3. Type the following into your .desktop file. Like before, try to guess what each line does.
 
-   ```text
+   ```ini
    [Desktop Entry]
    Name=Hello Again
    GenericName=Hello World App
@@ -82,7 +82,7 @@ Every app also comes with an .appdata.xml file. This file contains all the infor
 1. In your data folder, create a new file called "hello-again.appdata.xml"
 2. Type the following into your .appdata.xml file
 
-   ```markup
+   ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <!-- Copyright 2019 Your Name <you@email.com> -->
    <component type="desktop">
@@ -100,7 +100,7 @@ These are all the mandatory fields for displaying your app in AppCenter. There a
 
 There are also some special custom fields for AppCenter to further brand your listing. Specifically, you can set a background color and a text color for your app's header and banner. You can do so by adding the following keys inside the `component` tag:
 
-```markup
+```xml
 <custom>
   <value key="x-appcenter-color-primary">#603461</value>
   <value key="x-appcenter-color-primary-text">rgb(255, 255, 255)</value>
@@ -132,4 +132,3 @@ If you'd like to better understand software licensing, the Linux Foundation offe
 Did you remember to add these files to `git` and commit a revision? Each time we add a new file or make a significant change it's a good idea to commit a new revision and push to GitHub. Keep in mind that this acts as a backup system as well; when we push our work to GitHub, we know it's safe and we can always revert to a known good revision if we mess up later.
 
 Now that we've got all these swanky files laying around, we need a way to tell the computer what to do with them. Ready for the next chapter? Let's do this!
-

--- a/writing-apps/our-first-app/continuous-integration.md
+++ b/writing-apps/our-first-app/continuous-integration.md
@@ -5,7 +5,7 @@ Continuous integration testing \(also called CI\), is a way to automatically ens
 1. Navigate to your project's page on GitHub and select the "Actions" tab.
 2. Select "set up a workflow yourself". You'll then be shown the `main.yml` file with GitHub's default CI configuration. Replace the default workflow with the following:
 
-```text
+```yaml
 name: CI
 
 # This workflow will run for any pull request or pushed commit

--- a/writing-apps/our-first-app/icons.md
+++ b/writing-apps/our-first-app/icons.md
@@ -52,7 +52,7 @@ You'll notice the section for installing app icons is a little more complicated 
 
 If you cannot see your new icon in the Applications Menu or the Dock once you've reinstalled your app, refresh your system's icon cache using the following command:
 
-```text
+```bash
 sudo update-icon-caches /usr/share/icons/*
 ```
 

--- a/writing-apps/our-first-app/translations.md
+++ b/writing-apps/our-first-app/translations.md
@@ -2,7 +2,7 @@
 
 Now that you've learned about Meson, the next step is to make your app able to be translated to different languages. The first thing you need to know is how to mark strings in your code as translatable. Here's an example:
 
-```csharp
+```vala
 stdout.printf ("Not Translatable string");
 stdout.printf (_("Translatable string!"));
 
@@ -67,10 +67,10 @@ Now we have to make some changes to our Meson build system and add a couple new 
 5. Now, Create a directory named "po" in the root folder of your project. Inside of your po directory you will need to create another "meson.build" file. This time, its contents will be:
 
    ```coffeescript
-    i18n.gettext(meson.project_name(),
-        args: '--directory=' + meson.source_root(),
-        preset: 'glib'
-    )
+   i18n.gettext(meson.project_name(),
+       args: '--directory=' + meson.source_root(),
+       preset: 'glib'
+   )
    ```
 
 6. Inside of "po" create another file called "POTFILES" that will contain paths to all of the files you want to translate. For us, this looks like:
@@ -122,8 +122,7 @@ If you're having trouble, you can view the full example code [here on GitHub](ht
 
 Sometimes detailed descriptions in the context of translatable strings are necessary for disambiguation or to help in the creation of accurate translations. For these situations use `/// TRANSLATORS:` comments.
 
-```csharp
+```vala
 /// TRANSLATORS: The first %s is search term, the second is the name of default browser
 title = _("Search for %s in %s").printf (query, get_default_browser_name ());
 ```
-


### PR DESCRIPTION
This makes the syntax highlighting languages consistent across the board:

- We no longer have to pretend to be C#, because Vala is now supported on GitBook. ([I tested it.](https://darshak-parikh.gitbook.io/untitled/))
- Meson can be reliably faked with `coffeescript`. We already do this on some pages; I just used it everywhere.
- `.desktop` entries can be reliably faked with `ini`.
- EditorConfig [is](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L1491) an `ini`.
- Changed `markup` to `xml`. Both work on GitBook, but `xml` is better supported elsewhere, like on GitHub and in text editors.
- AppCenter badge snippets can be highlighted with `markdown` and `html`.