### PR TITLE
Rework sections on metadata

### DIFF
--- a/appcenter/publishing-requirements.md
+++ b/appcenter/publishing-requirements.md
@@ -28,17 +28,17 @@ AppCenter supports publishing apps that meet these requirements; extensions or p
 
 In general, your app's metadata should not refer to "elementary" or "elementary OS" in user-facing strings—it is assumed that all apps submitted to AppCenter are designed for elementary OS, and users don't need to be reminded of this. If there is a rare, legitimate reason for mentioning elementary, it must abide by the [elementary Brand Guidelines](https://elementary.io/brand).
 
-#### AppData and OARS
+#### MetaInfo and OARS
 
-Your app must install an [appdata.xml file](https://docs.elementary.io/develop/writing-apps/our-first-app#appdata-xml) to `/usr/share/metainfo`. AppCenter uses this metadata to create a listing for your app. It cannot be displayed in AppCenter without it.
+Your app must install an [metainfo.xml file](https://docs.elementary.io/develop/writing-apps/our-first-app#metainfo-xml) to `/usr/share/metainfo`. AppCenter uses this metadata to create a listing for your app. It cannot be displayed in AppCenter without it.
 
-Your appdata.xml file must contain a `screenshot` tag that references a screenshot of your app with elementary OS default settings including the GTK stylesheet, icons, window button position, etc. Screenshots referenced in your AppData should not contain marketing copy, illustrations, or other elements aside from a full-window screenshot of your app in use.
+Your metainfo.xml file must contain a `screenshot` tag that references a screenshot of your app with elementary OS default settings including the GTK stylesheet, icons, window button position, etc. Screenshots referenced in your MetaInfo should not contain marketing copy, illustrations, or other elements aside from a full-window screenshot of your app in use.
 
-Your appdata.xml file must contain a `developer_name` tag that references your name or the name of your organization.
+Your metainfo.xml file must contain a `developer_name` tag that references your name or the name of your organization.
 
-Your appdata.xml must include accurate [Open Age Rating Service \(OARS\)](https://hughsie.github.io/oars/) data. OARS uses a short, self-reported survey that only takes a few moments to output the required XML. Reviewers will check this data for accuracy in order for your app to be published.
+Your metainfo.xml must include accurate [Open Age Rating Service \(OARS\)](https://hughsie.github.io/oars/) data. OARS uses a short, self-reported survey that only takes a few moments to output the required XML. Reviewers will check this data for accuracy in order for your app to be published.
 
-For more information about the appdata.xml format see, see the [appstream specification](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps).
+For more information about the metainfo.xml format see, see the [appstream specification](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps).
 
 #### Desktop File
 

--- a/appcenter/publishing-updates.md
+++ b/appcenter/publishing-updates.md
@@ -4,7 +4,7 @@ After your app has been published in AppCenter, you can issue a new update at an
 
 ## Updating Screenshots
 
-Screenshots are uploaded to the AppCenter screenshot server at publication time. The URL referenced in your AppData.xml file will be automatically replaced during publication and any changes you make to images hosted at the remote URL will not be reflected in AppCenter.
+Screenshots are uploaded to the AppCenter screenshot server at publication time. The URL referenced in your MetaInfo file will be automatically replaced during publication and any changes you make to images hosted at the remote URL will not be reflected in AppCenter.
 
 {% hint style="info" %}
 If you change the UI of your app in an update, you **must** update your screenshots
@@ -12,7 +12,7 @@ If you change the UI of your app in an update, you **must** update your screensh
 
 ## Release Descriptions
 
-You must add accurate release descriptions to your appdata.xml file when publishing an update. For more information on formatting, see the [FreeDesktop.org AppStream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent) for the `<releases />` tag. The version in your release should match the latest version submitted to AppCenter.
+You must add accurate release descriptions to your metainfo.xml file when publishing an update. For more information on formatting, see the [FreeDesktop.org AppStream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent) for the `<releases />` tag. The version in your release should match the latest version submitted to AppCenter.
 
 Release descriptions should be accurate, concise, and written for a typical user of your app—focus on user-visible and user-understandable changes, and simplify or omit technical "under the hood" changes. For example, a good release description might be:
 
@@ -34,7 +34,7 @@ Release descriptions should be accurate, concise, and written for a typical user
 > * Refactored utils
 > * Updated VAPIs
 
-Previous release descriptions can remain in your AppData in perpetuity; AppCenter may use these to display cumulative descriptions between an older installed version and the latest version.
+Previous release descriptions can remain in your MetaInfo file in perpetuity; AppCenter may use these to display cumulative descriptions between an older installed version and the latest version.
 
 ## GitHub User/Org Name Changes
 

--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -71,7 +71,7 @@ First is a MetaInfo file. This file contains all the information needed to list 
 
 In your project's root, create a new folder called "data", and save your MetaInfo to a new file called "hello-again.metainfo.xml".
 
-For the purposes of this tutorial, screenshots are optional, but they are required for publishing in AppCenter. OARS data is also required and can be generated with the [OARS generator](https://hughsie.github.io/oars/generate.html).
+For the purposes of this tutorial, screenshots are optional, but they are required for publishing in AppCenter. OARS data is also required and can be generated with the [OARS generator](https://hughsie.github.io/oars/generate.html). There are even more [optional fields](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html) that you can read about.
 
 There are also some special custom fields for AppCenter to further brand your listing. Specifically, you can set a background color and a text color for your app's header and banner. You can do so by adding the following keys inside the `component` tag:
 

--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -98,7 +98,7 @@ To monetize your app, you also **must include your app's AppCenter Stripe key**.
 
 This file contains all the information needed to display your app in the Applications Menu and in the Dock. The one generated from AppStream Metainfo Creator looks something like this:
 
-```
+```ini
 [Desktop Entry]
 Version=1.0
 Type=Application

--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -40,63 +40,38 @@ To create our first real app, we're going to need all the old stuff that we used
 
 Everything working as expected? Good. Now, let's get our app ready for other people to use.
 
-## The .desktop File
+## Metadata
 
-Every app comes with a .desktop file. This file contains all the information needed to display your app in the Applications Menu and in the Dock. Let's go ahead and make one:
+Every app comes with two metadata files that we can generate using an online tool. Open [AppStream Metainfo Creator](https://www.freedesktop.org/software/appstream/metainfocreator/#/guiapp) and fill out the form with your app's info. When you get the section titled "Launchables", make sure to select "Generate a .desktop file for me". Don't worry about generating Meson snippets, as we'll cover that in the next section. After you select "Generate", you should have two resulting files that you can copy.
 
-1. In your project's root, create a new folder called "data".
-2. Create a new file in Code and save it in the "data" folder as "hello-again.desktop".
-3. Type the following into your .desktop file. Like before, try to guess what each line does.
+### The MetaInfo File
 
-   ```ini
-   [Desktop Entry]
-   Name=Hello Again
-   GenericName=Hello World App
-   Comment=Proves that we can use Vala and Gtk
-   Categories=Utility;Education;
-   Exec=com.github.yourusername.yourrepositoryname
-   Icon=com.github.yourusername.yourrepositoryname
-   Terminal=false
-   Type=Application
-   Keywords=Hello;World;Example;
-   ```
+First is a MetaInfo file. This file contains all the information needed to list your app in AppCenter. It should look something like this:
 
-   The first line declares that this file is a "Desktop Entry" file. The next three lines are descriptions of our app: The branded name of our app, a generic name for our app, and a comment that describes our app's function. Next, we categorize our app. Then, we say what command will execute it. Finally, we give our app an icon and let the OS know that this isn't a command line app.
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.github.myteam.myapp</id>
 
-{% hint style="info" %}
-For more info about crafting .desktop files, check out [this HIG entry](https://docs.elementary.io/hig/desktop-integration/app-launcher).
-{% endhint %}
+  <name>My App</name>
+  <summary>Proves that we can use Vala and Gtk</summary>
 
-1. Finally, let's add this file to `git` and commit a revision:
+  <metadata_license>CC-BY-4.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
 
-   ```bash
-   git add data/hello-again.desktop
-   git commit -am "Add a .desktop file"
-   git push
-   ```
+  <description>
+    <p>
+      A quick summary of your app's main selling points and features. Just a couple sentences per paragraph is best
+    </p>
+  </description>
 
-## AppData.xml
+  <launchable type="desktop-id">com.github.myteam.myapp.desktop</launchable>
+</component>
+```
 
-Every app also comes with an .appdata.xml file. This file contains all the information needed to list your app in AppCenter.
+In your project's root, create a new folder called "data", and save your MetaInfo to a new file called "hello-again.metainfo.xml".
 
-1. In your data folder, create a new file called "hello-again.appdata.xml"
-2. Type the following into your .appdata.xml file
-
-   ```xml
-   <?xml version="1.0" encoding="UTF-8"?>
-   <!-- Copyright 2019 Your Name <you@email.com> -->
-   <component type="desktop">
-     <id>com.github.yourusername.yourrepositoryname</id>
-     <metadata_license>CC0</metadata_license>
-     <name>Your App's Name</name>
-     <summary>A Catchy Tagline</summary>
-     <description>
-       <p>A quick summary of your app's main selling points and features. Just a couple sentences per paragraph is best.</p>
-     </description>
-   </component>
-   ```
-
-These are all the mandatory fields for displaying your app in AppCenter. There are plenty of other [optional fields](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html) that you can read about.
+For the purposes of this tutorial, screenshots are optional, but they are required for publishing in AppCenter. OARS data is also required and can be generated with the [OARS generator](https://hughsie.github.io/oars/generate.html).
 
 There are also some special custom fields for AppCenter to further brand your listing. Specifically, you can set a background color and a text color for your app's header and banner. You can do so by adding the following keys inside the `component` tag:
 
@@ -117,8 +92,40 @@ You can also specify a suggested price in whole USD.
 Remember that AppCenter is a pay-what-you-want store. A suggested price is not a price floor. Users will still be able to choose any price they like, including 0.
 {% endhint %}
 
-To monetize your app, you also **must include your app's AppCenter Stripe key**. This is a unique public key for each app and is not the same as your Stripe account's regular public key. While the new AppCenter Dashboard is under development, elementary OS 5.1 app developers can find your app's key in its [existing AppStream data](https://appstream.elementary.io/appcenter/html/bionic/main/metainfo/index.html). Developers of new apps will receive their key in the new AppCenter Dashboard once it is live.
+To monetize your app, you also **must include your app's AppCenter Stripe key**. This is a unique public key for each app and is not the same as your Stripe account's regular public key. You can connect your app to Stripe and receive a new key on the [AppCenter Dashboard](https://beta.developer.elementary.io/).
 
+### The Desktop Entry File
+
+This file contains all the information needed to display your app in the Applications Menu and in the Dock. The one generated from AppStream Metainfo Creator looks something like this:
+
+```
+[Desktop Entry]
+Version=1.0
+Type=Application
+
+Name=My App
+Comment=Proves that we can use Vala and Gtk
+Categories=Development;Education;
+
+Icon=com.github.myteam.myapp
+Exec=com.github.myteam.myapp
+Terminal=false
+```
+
+Copy the contents of your Desktop Entry and save it to the data folder you created earlier. Name this new file "hello-again.desktop".
+
+{% hint style="info" %}
+For more info about crafting .desktop files, check out [this HIG entry](https://docs.elementary.io/hig/desktop-integration/app-launcher).
+{% endhint %}
+
+1. Finally, let's add both of these files to `git` and commit a revision:
+
+   ```bash
+   git add data/
+   git commit -am "Add Metadata files"
+   git push
+   ```
+   
 ## Legal Stuff
 
 Since we're going to be putting our app out into the wild, we should include some information about who wrote it and the legal usage of its source code. For this we need a new file in our project's root folder: the `LICENSE` file. This file contains a copy of the license that your code is released under. For elementary OS apps this is typically the [GNU General Public License](https://www.gnu.org/licenses/quick-guide-gplv3.html) \(GPL\). Remember the header we added to our source code? That header reminds people that your app is licensed and it belongs to you. GitHub has a built-in way to add several popular licenses to your repository. Read their [documentation for adding software licenses](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository) and add a `LICENSE` file to your repository.

--- a/writing-apps/our-first-app/packaging.md
+++ b/writing-apps/our-first-app/packaging.md
@@ -8,7 +8,7 @@ If you want to get really good really fast, you're going to want to practice. Re
 
 1. Create a new branch folder "hello-packaging"
 2. Set up our directory structure including the "src" and "data" folders.
-3. Add your Copying, .desktop, .appdata.xml, icons, and source code.
+3. Add your Copying, .desktop, .metainfo.xml, icons, and source code.
 4. Now set up the Meson build system and translations.
 5. Test everything!
 

--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -4,7 +4,7 @@ description: Compiling Binaries & Installing Data with Meson
 
 # The Build System
 
-The next thing we need is a build system. The build system that we're going to be using is called [Meson](https://mesonbuild.com/). We already installed the `meson` program at the beginning of this book when we installed `elementary-sdk`. What we're going to do in this step is create the files that tell Meson how to install your program. This includes all the rules for building your source code as well as correctly installing your icons, .desktop, and appdata files and the binary app that results from the build process.
+The next thing we need is a build system. The build system that we're going to be using is called [Meson](https://mesonbuild.com/). We already installed the `meson` program at the beginning of this book when we installed `elementary-sdk`. What we're going to do in this step is create the files that tell Meson how to install your program. This includes all the rules for building your source code as well as correctly installing your icons, .desktop, and metainfo files and the binary app that results from the build process.
 
 Create a new file in your project's root folder called "meson.build". We've included some comments along the way to explain what each section does. You don't have to copy those, but type the rest into that file:
 
@@ -29,11 +29,11 @@ install_data(
     rename: meson.project_name() + '.desktop'
 )
 
-# Install our .appdata.xml file so AppCenter will see it
+# Install our .metainfo.xml file so AppCenter will see it
 install_data(
-    'data' / 'hello-again.appdata.xml',
+    'data' / 'hello-again.metainfo.xml',
     install_dir: get_option('datadir') / 'metainfo',
-    rename: meson.project_name() + '.appdata.xml'
+    rename: meson.project_name() + '.metainfo.xml'
 )
 ```
 

--- a/writing-apps/our-first-app/translations.md
+++ b/writing-apps/our-first-app/translations.md
@@ -24,7 +24,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
    add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
    ```
 
-2. Remove the lines that install your .desktop and appdata files and replace them with the following:
+2. Remove the lines that install your .desktop and metainfo files and replace them with the following:
 
    ```coffeescript
    #Translate and install our .desktop file
@@ -37,10 +37,10 @@ Now we have to make some changes to our Meson build system and add a couple new 
        install_dir: get_option('datadir') / 'applications'
    )
 
-   #Translate and install our .appdata file
+   #Translate and install our .metainfo file
    i18n.merge_file(
-       input: 'data' / 'hello-again.appdata.xml.in',
-       output: meson.project_name() + '.appdata.xml',
+       input: 'data' / 'hello-again.metainfo.xml.in',
+       output: meson.project_name() + '.metainfo.xml',
        po_dir: meson.source_root() / 'po',
        install: true,
        install_dir: get_option('datadir') / 'metainfo'
@@ -55,11 +55,11 @@ Now we have to make some changes to our Meson build system and add a couple new 
    subdir('po')
    ```
 
-4. You might have noticed in step 2 that the `merge_file` method has an `input` and `output`. We're going to append the additional extension `.in` to our .desktop and .appdata.xml files so that this method can take the untranslated files and produce translated files with the correct names.
+4. You might have noticed in step 2 that the `merge_file` method has an `input` and `output`. We're going to append the additional extension `.in` to our .desktop and .metainfo.xml files so that this method can take the untranslated files and produce translated files with the correct names.
 
    ```bash
    git mv data/hello-again.desktop data/hello-again.desktop.in
-   git mv data/hello-again.appdata.xml data/hello-again.appdata.xml.in
+   git mv data/hello-again.metainfo.xml data/hello-again.metainfo.xml.in
    ```
 
    We use the `git mv` command here instead of renaming in the file manager or with `mv` so that `git` can keep track of the file rename as part of our revision history.
@@ -78,7 +78,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
    ```text
    src/Application.vala
    data/hello-again.desktop.in
-   data/hello-again.appdata.xml.in
+   data/hello-again.metainfo.xml.in
    ```
 
 7. We have one more file to create in the "po" directory. This file will be named "LINGUAS" and it should contain the two-letter language codes for all languages you want to provide translations for. As an example, let's add German and Spanish


### PR DESCRIPTION
Fixes #7
Fixes #63
Fixes #156

It looks like "AppData" is an outdated term and everything is referred to as "metainfo" now.

The AppStream generator doesn't do anything with GenericName and we never expose it anywhere anyways, so I just left that out. Keywords are also covered in the linked HIG entry, so I think it's nbd if we omit them here.