### PR TITLE
README: add links to GTK and Granite; break lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ description: Creating and distributing apps for elementary OS
 
 ## What is \(and Isn't\) Covered
 
-No experience in writing apps for elementary OS is assumed, but basic programming knowledge is. A little experience with Vala (or at least similarly syntaxed languages) will be valuable. If you're not familiar with Vala, there are great resources (text and video) available for learning Vala on [Valadoc.org](https://valadoc.org/).
+No experience in writing apps for elementary OS is assumed, but basic programming knowledge is.
+A little experience with Vala (or at least similarly syntaxed languages) will be valuable.
+If you're not familiar with Vala, there are great resources (text and video) available for learning Vala on [Valadoc.org](https://valadoc.org/).
 
-Design is covered in the [Human Interface Guidelines \(HIG\)](https://docs.elementary.io/hig/). We reference the HIG throughout this guide and it's important you grasp the concepts proposed there, but this guide is focused primarily on code.
+Design is covered in the [Human Interface Guidelines \(HIG\)](https://docs.elementary.io/hig/).
+We reference the HIG throughout this guide and it's important you grasp the concepts proposed there, but this guide is focused primarily on code.
 
 ## Writing Apps
 
 This guide details:
-* Building apps using GTK, Granite, and other technology available in elementary OS
+* Building apps using [GTK](https://www.gtk.org), [Granite](https://github.com/elementary/granite), and other technology available in elementary OS
 * Setting up a build system
 * Hosting your code for collaborative development
 * Working with translations
@@ -24,7 +27,8 @@ You may feel confident enough to jump straight into writing your first appp:
 
 {% page-ref page="writing-apps/our-first-app/" %}
 
-However, we strongly recommend to at least skim "The Basic Setup" first. Having the right setup is going to help you reach your goals faster, and a solid foundation is going to help you throughout the rest of this book.
+However, we strongly recommend to at least skim "The Basic Setup" first.
+Having the right setup is going to help you reach your goals faster, and a solid foundation is going to help you throughout the rest of this book.
 
 {% page-ref page="writing-apps/the-basic-setup.md" %}
 
@@ -33,4 +37,3 @@ However, we strongly recommend to at least skim "The Basic Setup" first. Having 
 There are also a number of technical, metadata, legal, and other requirements for publishing your app to users via AppCenter.
 
 {% page-ref page="appcenter/publishing-requirements.md" %}
-


### PR DESCRIPTION
I also considered unescaping the parentheses — what is the reason for them being entered as `\(` and `\)`?