### PR TITLE
Actions and launchers

### DIFF
--- a/apis/actions.md
+++ b/apis/actions.md
@@ -11,14 +11,12 @@ GTK and GLib have a powerful API called [`GLib.Action`](https://valadoc.org/gio-
 Begin by creating a `Gtk.Application` with a `Gtk.ApplicationWindow` as you've done in previous examples. Once you have that set up, let's create a new [`Gtk.HeaderBar`](https://valadoc.org/gtk+-3.0/Gtk.HeaderBar.html). Typically your app will have a HeaderBar, at the top of the window, which will contain tool items that users will interact with to trigger your app's actions.
 
 ```vala
-private Gtk.ApplicationWindow main_window;
-
 protected override void activate () {
     var header_bar = new Gtk.HeaderBar () {
         show_close_button = true
     };
 
-    main_window = new Gtk.ApplicationWindow (this) {
+    var main_window = new Gtk.ApplicationWindow (this) {
         default_height = 300,
         default_width = 300,
         title = "Actions"
@@ -63,11 +61,7 @@ public override void startup () {
 
 	add_action (quit_action);
 	set_accels_for_action ("app.quit",  {"<Control>q", "<Control>w"});
-	quit_action.activate.connect (() => {
-		if (main_window != null) {
-			main_window.destroy ();
-		}
-	});
+	quit_action.activate.connect (quit);
 }
 ```
 
@@ -76,7 +70,7 @@ You'll notice that we do a few things here:
 * Instantiate a new [`GLib.SimpleAction`](https://valadoc.org/gio-2.0/GLib.SimpleAction.html) with the name "quit"
 * Add the action to our `Gtk.Application`'s [`ActionMap`](https://valadoc.org/gio-2.0/GLib.ActionMap.html)
 * Set the "accelerators" \(keyboard shortcuts\) for "app.quit" to `<Control>q` and `<Control>w"`. Notice that the action name is prefixed with `app`; this refers to the `ActionMap` built in to `Gtk.Application`
-* Connect to the `activate` signal of our `SimpleAction` and call `destroy ()` on `main_window`. This is why we saved `main_window` in a private field.
+* Connect the `activate` signal of our `SimpleAction` to Application's [quit method](https://valadoc.org/gio-2.0/GLib.Application.quit.html).
 
 {% hint style="info" %}
 Actions defined like this, and registered with the application, can be used as entry points into the app. You can find out more about this integration in [the launchers section](launchers#actions).

--- a/apis/actions.md
+++ b/apis/actions.md
@@ -55,13 +55,13 @@ Let's define a new Quit action and register it with `Application` from inside th
 
 ```vala
 public override void startup () {
-	base.startup ();
+    base.startup ();
 
-	var quit_action = new SimpleAction ("quit", null);
+    var quit_action = new SimpleAction ("quit", null);
 
-	add_action (quit_action);
-	set_accels_for_action ("app.quit",  {"<Control>q", "<Control>w"});
-	quit_action.activate.connect (quit);
+    add_action (quit_action);
+    set_accels_for_action ("app.quit",  {"<Control>q", "<Control>w"});
+    quit_action.activate.connect (quit);
 }
 ```
 
@@ -73,7 +73,7 @@ You'll notice that we do a few things here:
 * Connect the `activate` signal of our `SimpleAction` to Application's [quit method](https://valadoc.org/gio-2.0/GLib.Application.quit.html).
 
 {% hint style="info" %}
-Actions defined like this, and registered with the application, can be used as entry points into the app. You can find out more about this integration in [the launchers section](launchers#actions).
+Actions defined like this, and registered with Application, can be used as entry points into the app. You can find out more about this integration in [the launchers section](launchers#actions).
 {% endhint %}
 
 Now we can tie the action to the HeaderBar Button by assigning the `action_name` property of our Button:
@@ -123,5 +123,5 @@ var button = new Gtk.Button.from_icon_name ("process-stop", Gtk.IconSize.LARGE_T
 Compile your app one last time and hover over the HeaderBar Button to see its description and associated keyboard shortcuts.
 
 {% hint style="info" %}
-If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/glib-action).
+If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/glib-action). You can learn more from `GLib.Action` [reference documentation](https://valadoc.org/gio-2.0/GLib.Action.html).
 {% endhint %}

--- a/apis/launchers.md
+++ b/apis/launchers.md
@@ -61,7 +61,7 @@ As you can see, the method `set_progress` takes a `double` value type and is a r
 
 ## Actions
 
-You can use any action defined in the `app` namespace as one of the entry points for your application. They appear in the context menu of your app icon in the Applications Menu and Dock, and are searchable by name from the Applications Menu. Implementing actions is covered in-depth in [the actions section](actions).
+Actions are specific functions your app can perform without already being open; think of them as alternate and more specific entry points into your app. Actions appear in the context menu of your app icon in the Applications Menu and Dock, and are searchable by name from the Applications Menu.
 
 ### D-Bus activation
 
@@ -100,19 +100,7 @@ DBusActivatable=true
 
 ### Declaring actions
 
-When defining a `GLib.Action` that can be used to launch the app make sure to register it inside application's `startup` method:
-
-```vala
-public override void startup () {
-	base.startup ();
-
-	var my_action = new SimpleAction ("my-action", null);
-	add_action (my_action);
-	// Add other actions, define keyboard shortcuts, etc.
-}
-```
-
-Actions must also be declared in a new `Actions` line in your app's `.desktop` file. This line should contain a `;` separated list of unique action names:
+You can use any action defined in the `app` namespace, i.e. registered with `GLib.Application`, as an entry point for your application. Implementing actions is covered in-depth in [the actions section](actions). They must also be declared in a new `Actions` line in your app's `.desktop` file. This line should contain a `;` separated list of action names:
 
 ```ini
 [Desktop Entry]
@@ -125,14 +113,20 @@ Then use a dedicated group, named after the unique action name, to define the de
 
 ```ini
 [Desktop Action my-action]
-Name=User visible name of my action
+Name=My Great Action
 Icon=com.github.myteam.myapp.my-action-icon
 Exec=com.github.myteam.myapp
 ```
 
-The `Icon` line is optional and should reference a dedicated icon for the action. The `Exec` line should be specified, but is used only for backwards compatibility in case your app ever runs in an environment without D-Bus activation support. Learn more from the [related Freedesktop specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html).
+{% hint style="warning" %}
+The action name used in `.desktop` file, both in Desktop Entry and later in Desktop Action groups, needs to match exactly the name used to register the action with `GLib.Applicatin` in the source code.
+{% endhint %}
+
+The `Icon` line is optional and should be an icon which represents the action that will be performed. The `Exec` line should be specified, but is used only for backwards compatibility in case your app ever runs in an environment without D-Bus activation support.
 
 {% hint style="info" %}
 The action name should not include your app's name, as it will always be displayed alongside your app. The action icon should also not be your app icon, as it may be shown in the menu for your app icon, or badged on top of the app icon.
 {% endhint %}
+
+See the [freedesktop.org Additional applications actions section](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html) for a detailed description of what keys are supported and what they do.
 

--- a/apis/notifications.md
+++ b/apis/notifications.md
@@ -90,10 +90,7 @@ You can also add buttons to notifications that will trigger actions defined in t
 var quit_action = new SimpleAction ("quit", null);
 
 add_action (quit_action);
-
-quit_action.activate.connect (() => {
-    main_window.destroy ();
-});
+quit_action.activate.connect (quit);
 ```
 
 Now, we can add a button to the notification with a translatable label and the action ID.


### PR DESCRIPTION
Resolve #180 
Resolve #179

I did several things here:

1. Explain how to enable DBus activation for an app (_Launchers_ page)
2. Explain how to declare launching actions (_Launchers_ page)
3. Add reference to launching actions (_Actions_ page)
4. Update examples to register action fro the `startup` method (both _Actions_ and _Launchers_ pages)

As discussed in the comments on the #180 issue, I think this is a minimum change which makes sense. We can't really leave any of these steps out and end up with a working app.

An alternative approach I considered was moving parts of this documentation, adding some more stuff and creating a new _Application lifecycle_ page. This new page could include discussion of DBus activation and differences between `startup`, `activate` and `open` signals. Perhaps we could also include a section on opening files, defining new file types and registering the app as default handler for those. But all that seemed to be too much scope for the 2 issues that I was trying to solve. So I gave up on the _Application lifecycle_ page approach and limited the changes to existing _Launchers_ and _Actions_ pages. If that approach sounds interesting I can try scoping it a bit and open a dedicate issue for the  _Application lifecycle_ page.