### PR TITLE
Action and launchers part 1

### DIFF
--- a/apis/actions.md
+++ b/apis/actions.md
@@ -51,21 +51,18 @@ If you compile your app, you can see that it now has a custom HeaderBar with a b
 
 ## GLib.SimpleAction
 
-Let's define a new Quit action by adding the following to the beginning of the `activate ()` method
+Let's define a new Quit action and register it with `Application` from inside the `startup` method:
 
 ```vala
-var quit_action = new SimpleAction ("quit", null);
+public override void startup () {
+    base.startup ();
 
-add_action (quit_action);
-set_accels_for_action ("app.quit",  {"<Control>q", "<Control>w"});
-```
+    var quit_action = new SimpleAction ("quit", null);
 
-and this to the end of the `activate ()` method:
-
-```vala
-quit_action.activate.connect (() => {
-    main_window.destroy ();
-});
+    add_action (quit_action);
+    set_accels_for_action ("app.quit",  {"<Control>q", "<Control>w"});
+    quit_action.activate.connect (quit);
+}
 ```
 
 You'll notice that we do a few things here:
@@ -73,9 +70,14 @@ You'll notice that we do a few things here:
 * Instantiate a new [`GLib.SimpleAction`](https://valadoc.org/gio-2.0/GLib.SimpleAction.html) with the name "quit"
 * Add the action to our `Gtk.Application`'s [`ActionMap`](https://valadoc.org/gio-2.0/GLib.ActionMap.html)
 * Set the "accelerators" \(keyboard shortcuts\) for "app.quit" to `<Control>q` and `<Control>w"`. Notice that the action name is prefixed with `app`; this refers to the `ActionMap` built in to `Gtk.Application`
-* Connect to the `activate` signal of our `SimpleAction` and call `destroy ()` on `main_window`. This must be at the end of `activate ()` because of that reference to `main_window`
+* Connect the `activate` signal of our `SimpleAction` to Application's [quit method](https://valadoc.org/gio-2.0/GLib.Application.quit.html).
 
-and now we can tie the action to the HeaderBar Button by assigning the `action_name` property of our Button:
+
+{% hint style="info" %}
+Accelerator strings follow a format defined by [`Gtk.accelerator_parse`](https://valadoc.org/gtk+-3.0/Gtk.accelerator_parse.html). You can find a list of key values [on Valadoc](https://valadoc.org/gdk-3.0/Gdk.Key.html)
+{% endhint %}
+
+Now we can tie the action to the HeaderBar Button by assigning the `action_name` property of our Button:
 
 ```vala
 var button = new Gtk.Button.from_icon_name ("process-stop", Gtk.IconSize.LARGE_TOOLBAR) {
@@ -93,7 +95,7 @@ Accelerator strings follow a format defined by [`Gtk.accelerator_parse`](https:/
 
 There's one more thing we can do here to help improve your app's usability. You may have noticed that in elementary apps you can hover your pointer over tool items to see a description of the button and any available keyboard shortcuts associated with it. We can add the same thing to our Button with [`Granite.markup_accel_tooltip ()`](https://valadoc.org/granite/Granite.markup_accel_tooltip.html).
 
-First, make sure you've included Granite in the build dependencies declared in your meson.build file:
+First, make sure you've included Granite in the build dependencies declared in your `meson.build` file:
 
 ```coffeescript
 executable(
@@ -119,10 +121,8 @@ var button = new Gtk.Button.from_icon_name ("process-stop", Gtk.IconSize.LARGE_T
 };
 ```
 
-It may now be clear why we needed to declare our action at the beginning of `activate ()`: before we can get a list of the accelerators associated with the action, we have to define those accelerations and add them to the Application.
-
 Compile your app one last time and hover over the HeaderBar Button to see its description and associated keyboard shortcuts.
 
 {% hint style="info" %}
-If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/glib-action)
+If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/glib-action). You can learn more from `GLib.Action` [reference documentation](https://valadoc.org/gio-2.0/GLib.Action.html).
 {% endhint %}

--- a/apis/actions.md
+++ b/apis/actions.md
@@ -54,7 +54,7 @@ If you compile your app, you can see that it now has a custom HeaderBar with a b
 Let's define a new Quit action and register it with `Application` from inside the `startup` method:
 
 ```vala
-public override void startup () {
+protected override void startup () {
     base.startup ();
 
     var quit_action = new SimpleAction ("quit", null);

--- a/apis/launchers.md
+++ b/apis/launchers.md
@@ -1,5 +1,5 @@
 ---
-description: Adding Badges, Progress Bars, and Quick Lists
+description: Adding Badges, Progress Bars, and launching Actions
 ---
 
 # Launchers
@@ -105,4 +105,4 @@ Exec=com.github.yourusername.yourrepositoryname -n
 
 Note that just adding `-n` or any other argument will not automatically make your app open a new window; your app must handle and interpret command line arguments. The [GLib.Application API](https://valadoc.org/gio-2.0/GLib.Application.html) provides many examples and an extensive documentation on how to handle these arguments, particularly the [command\_line signal](https://valadoc.org/gio-2.0/GLib.Application.command\_line.html).
 
-See the [freedesktop.org Additional applications actions section](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s10.html) for a detailed description of what keys are supported and what they do.
+See the [freedesktop.org Additional applications actions section](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s11.html) for a detailed description of what keys are supported and what they do.

--- a/apis/notifications.md
+++ b/apis/notifications.md
@@ -90,10 +90,7 @@ You can also add buttons to notifications that will trigger actions defined in t
 var quit_action = new SimpleAction ("quit", null);
 
 add_action (quit_action);
-
-quit_action.activate.connect (() => {
-    main_window.destroy ();
-});
+quit_action.activate.connect (quit);
 ```
 
 Now, we can add a button to the notification with a translatable label and the action ID.


### PR DESCRIPTION
First part of changes proposed in #182. This PR:

1. Updates code snippets (and accompanying text) of Actions, and to a lesser extend Notifications, sections to reflect the latest state of showcase app in [vala-lang/examples](https://github.com/vala-lang/examples/tree/glib-action).
2. Fixes section description and a URL link to freedesktop specification page in the Launchers section.