### PR TITLE
Fix broken link to launchers on api/actions page

### DIFF
--- a/apis/actions.md
+++ b/apis/actions.md
@@ -102,7 +102,7 @@ Accelerator strings follow a format defined by [`Gtk.accelerator_parse`](https:/
 {% endhint %}
 
 {% hint style="info" %}
-Actions defined like this, and registered with Application, can be used as entry points into the app. You can find out more about this integration in [the launchers section](launchers/#actions).
+Actions defined like this, and registered with Application, can be used as entry points into the app. You can find out more about this integration in [the launchers section](./launchers#actions).
 {% endhint %}
 
 ## Granite.markup\_accel\_tooltip


### PR DESCRIPTION
The link (before this Pull Request) goes to a 404 page on GitHub: <https://github.com/elementary/docs/blob/master/apis/launchers/README.md#actions>

I think, but am not sure, that the trailing slash is the problem.

Feel free to remove the preceding `./` (not sure the style here, but it's a page that is a direct sibling, so my prose is just being explicit).
