### PR TITLE
Use "io.github" prefix for RDNN

### DIFF
--- a/apis/gresource.md
+++ b/apis/gresource.md
@@ -15,7 +15,7 @@ Make sure to start with a `Gtk.Application` as described in the [previous sectio
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="com/github/myteam/myapp">
+  <gresource prefix="io/github/myteam/myapp">
   </gresource>
 </gresources>
 ```
@@ -58,7 +58,7 @@ Add a custom icon to the `data` directory, and then update your `gresource.xml` 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="com/github/myteam/myapp/icons">
+  <gresource prefix="io/github/myteam/myapp/icons">
     <file compressed="true" preprocess="xml-stripblanks">custom-icon.svg</file>
   </gresource>
 </gresources>
@@ -69,7 +69,7 @@ If you want to use the same icon name in multiple sizes in your app, you can `al
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="com/github/myteam/myapp/icons">
+  <gresource prefix="io/github/myteam/myapp/icons">
     <file alias="24x24/actions/custom-icon.svg" compressed="true" preprocess="xml-stripblanks">custom-icon-24.svg</file>
     <file alias="24x24@2/actions/custom-icon.svg" compressed="true" preprocess="xml-stripblanks">custom-icon-24.svg</file>
     <file alias="32x32/actions/custom-icon.svg" compressed="true" preprocess="xml-stripblanks">custom-icon-32.svg</file>

--- a/apis/launchers.md
+++ b/apis/launchers.md
@@ -70,8 +70,8 @@ Your app needs to support D-Bus activation in order to use actions as entry poin
 {% code title="myapp.service" %}
 ```ini
 [D-BUS Service]
-Name=com.github.myteam.myapp
-Exec=com.github.myteam.myapp --gapplication-service
+Name=io.github.myteam.myapp
+Exec=io.github.myteam.myapp --gapplication-service
 ```
 {% endcode %}
 
@@ -114,8 +114,8 @@ Then use a dedicated group, named after the unique action name, to define the de
 ```ini
 [Desktop Action my-action]
 Name=My Great Action
-Icon=com.github.myteam.myapp.my-action-icon
-Exec=com.github.myteam.myapp
+Icon=io.github.myteam.myapp.my-action-icon
+Exec=io.github.myteam.myapp
 ```
 
 {% hint style="warning" %}

--- a/apis/state-saving.md
+++ b/apis/state-saving.md
@@ -11,7 +11,7 @@ First, you need to define what settings your app will use so they can be accesse
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema path="/com/github/yourusername/yourrepositoryname/" id="com.github.yourusername.yourrepositoryname">
+  <schema path="/io/github/yourusername/yourrepositoryname/" id="io.github.yourusername.yourrepositoryname">
     <key name="useless-setting" type="b">
       <default>false</default>
       <summary>Useless Setting</summary>
@@ -41,7 +41,7 @@ protected override void activate () {
     };
     main_window.present ();
 
-    var settings = new Settings ("com.github.yourusername.yourrepositoryname");
+    var settings = new Settings ("io.github.yourusername.yourrepositoryname");
     settings.bind ("useless-setting", useless_switch, "active", DEFAULT);
 }
 ```
@@ -79,7 +79,7 @@ Compile and install your app to see it in action!
 GSettings are installed at install time, not compile time. So you'll need to run `ninja install` to avoid crashes from not-yet-installed settings.
 {% endhint %}
 
-To see the state saving functionality in action, you can open your app, toggle the switch, close it, then re-open it. The switch should retain its previous state. To see it under the hood, open dconf Editor, navigate to your app's settings at com.github.yourusername.yourrepositoryname, and watch the `useless-setting` update in real time when you toggle your switch.
+To see the state saving functionality in action, you can open your app, toggle the switch, close it, then re-open it. The switch should retain its previous state. To see it under the hood, open dconf Editor, navigate to your app's settings at io.github.yourusername.yourrepositoryname, and watch the `useless-setting` update in real time when you toggle your switch.
 
 {% hint style="info" %}
 If you're having trouble, you can view the full example code [here on GitHub](https://github.com/vala-lang/examples/tree/gsettings)

--- a/appcenter/markdown-badges.md
+++ b/appcenter/markdown-badges.md
@@ -2,21 +2,21 @@
 
 elementary provides badges, e.g. for your GitHub README. Badges will open to your app's page on the AppCenter website where users can learn more about your app, see screenshots, and decide to download it. They look like this:
 
-[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.USER.REPO)
+[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/io.github.USER.REPO)
 
 ## Markdown
 
 ```markdown
-[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.USER.REPO)
+[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/io.github.USER.REPO)
 ```
 
 ## HTML
 
 ```html
-<a href="https://appcenter.elementary.io/com.github.USER.REPO"><img src="https://appcenter.elementary.io/badge.svg" alt="Get it on AppCenter"></a>
+<a href="https://appcenter.elementary.io/io.github.USER.REPO"><img src="https://appcenter.elementary.io/badge.svg" alt="Get it on AppCenter"></a>
 ```
 
 {% hint style="info" %}
-Make sure to replace `com.github.USER.REPO` in the URL with the ID for your app
+Make sure to replace `io.github.USER.REPO` in the URL with the ID for your app
 {% endhint %}
 

--- a/writing-apps/hello-world.md
+++ b/writing-apps/hello-world.md
@@ -23,7 +23,7 @@ In this file, we're going to create a special class called a `Gtk.Application`. 
 public class MyApp : Gtk.Application {
     public MyApp () {
         Object (
-            application_id: "com.github.yourusername.yourrepositoryname",
+            application_id: "io.github.yourusername.yourrepositoryname",
             flags: ApplicationFlags.FLAGS_NONE
         );
     }

--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -27,7 +27,7 @@ The results should look like this:
  public class MyApp : Gtk.Application {
     public MyApp () {
         Object (
-            application_id: "com.github.yourusername.yourrepositoryname",
+            application_id: "io.github.yourusername.yourrepositoryname",
             flags: ApplicationFlags.FLAGS_NONE
         );
     }

--- a/writing-apps/our-first-app/continuous-integration.md
+++ b/writing-apps/our-first-app/continuous-integration.md
@@ -34,7 +34,7 @@ jobs:
         # This is the name of the Bundle file we're building and can be anything you like
         bundle: MyApp.flatpak
         # This uses your app's RDNN ID
-        manifest-path: com.github.yourusername.yourrepositoryname.yml
+        manifest-path: io.github.yourusername.yourrepositoryname.yml
 
         # You can automatically run any of the tests you've created as part of this workflow
         run-tests: true

--- a/writing-apps/our-first-app/metadata.md
+++ b/writing-apps/our-first-app/metadata.md
@@ -23,7 +23,7 @@ First is a MetaInfo file. This file contains all the information needed to list 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>com.github.myteam.myapp</id>
+  <id>io.github.myteam.myapp</id>
 
   <name>My App</name>
   <summary>Proves that we can use Vala and Gtk</summary>
@@ -37,7 +37,7 @@ First is a MetaInfo file. This file contains all the information needed to list 
     </p>
   </description>
 
-  <launchable type="desktop-id">com.github.myteam.myapp.desktop</launchable>
+  <launchable type="desktop-id">io.github.myteam.myapp.desktop</launchable>
 </component>
 ```
 
@@ -129,8 +129,8 @@ Name=My App
 Comment=Proves that we can use Vala and Gtk
 Categories=Development;Education;
 
-Icon=com.github.myteam.myapp
-Exec=com.github.myteam.myapp
+Icon=io.github.myteam.myapp
+Exec=io.github.myteam.myapp
 Terminal=false
 ```
 

--- a/writing-apps/our-first-app/packaging.md
+++ b/writing-apps/our-first-app/packaging.md
@@ -16,11 +16,11 @@ Did you commit and push to GitHub for each step? Keep up these good habits and l
 
 ## Flatpak Manifest
 
-The Flatpak manifest file describes your app's build dependencies and required permissions. Create a `com.github.yourusername.yourrepositoryname.yml` file in your project root with the following contents:
+The Flatpak manifest file describes your app's build dependencies and required permissions. Create a `io.github.yourusername.yourrepositoryname.yml` file in your project root with the following contents:
 
 ```yaml
 # This is the same ID that you've used in meson.build and other files
-app-id: com.github.yourusername.yourrepositoryname
+app-id: io.github.yourusername.yourrepositoryname
 
 # Instead of manually specifying a long list of build and runtime dependencies,
 # we can use a convenient pre-made runtime and SDK. For this example, we'll be
@@ -31,7 +31,7 @@ sdk: io.elementary.Sdk
 
 # This should match the exec line in your .desktop file and usually is the same
 # as your app ID
-command: com.github.yourusername.yourrepositoryname
+command: io.github.yourusername.yourrepositoryname
 
 # Here we can specify the kinds of permissions our app needs to run. Since we're
 # not using hardware like webcams, making sound, or reading external files, we
@@ -55,7 +55,7 @@ modules:
 To run a test build and install your app, we can use `flatpak-builder` with a few arguments:
 
 ```bash
-flatpak-builder build com.github.yourusername.yourrepositoryname.yml --user --install --force-clean
+flatpak-builder build io.github.yourusername.yourrepositoryname.yml --user --install --force-clean
 ```
 
 This tells Flatpak Builder to build the manifest we just wrote into a clean `build` folder the same as we did for Meson. Plus, we install the built Flatpak package locally for our user. If all goes well, congrats! You've just built and installed your app as a Flatpak.
@@ -69,18 +69,18 @@ Ninja and Flatpak both provide commands to uninstalling the application.  It is 
 To remove our application with Flatpak, we will use Flatpak's `remove` command:
 
 ```bash
-flatpak remove com.github.yourusername.yourrepositoryname
+flatpak remove io.github.yourusername.yourrepositoryname
 ```
 
 Flatpak will prompt you to remove your application.
 
 ```bash
-flatpak uninstall com.github.yourusername.yourrepositoryname --delete-data
+flatpak uninstall io.github.yourusername.yourrepositoryname --delete-data
 
 
         ID                                                          Branch           Op
- 1.     com.github.yourusername.yourrepositoryname                  master           r
- 2.     com.github.yourusername.yourrepositoryname.Locale           master           r
+ 1.     io.github.yourusername.yourrepositoryname                  master           r
+ 2.     io.github.yourusername.yourrepositoryname.Locale           master           r
 
 Proceed with these changes to the user installation? [Y/n]:
 ```

--- a/writing-apps/our-first-app/packaging.md
+++ b/writing-apps/our-first-app/packaging.md
@@ -79,8 +79,8 @@ flatpak uninstall io.github.yourusername.yourrepositoryname --delete-data
 
 
         ID                                                          Branch           Op
- 1.     io.github.yourusername.yourrepositoryname                  master           r
- 2.     io.github.yourusername.yourrepositoryname.Locale           master           r
+ 1.     io.github.yourusername.yourrepositoryname                   master           r
+ 2.     io.github.yourusername.yourrepositoryname.Locale            master           r
 
 Proceed with these changes to the user installation? [Y/n]:
 ```

--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -10,7 +10,7 @@ Create a new file in your project's root folder called "meson.build". We've incl
 
 ```coffeescript
 # project name and programming language
-project('com.github.yourusername.yourrepositoryname', 'vala', 'c')
+project('io.github.yourusername.yourrepositoryname', 'vala', 'c')
 
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install
 executable(

--- a/writing-apps/our-first-app/translations.md
+++ b/writing-apps/our-first-app/translations.md
@@ -91,7 +91,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
 8. Now it's time to go back to your build directory and generate some new files using Terminal! The first one is our translation template or `.pot` file:
 
    ```bash
-   ninja com.github.yourusername.yourrepositoryname-pot
+   ninja io.github.yourusername.yourrepositoryname-pot
    ```
 
    After running this command you should notice a new file in the po directory containing all of the translatable strings for your app.
@@ -99,7 +99,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
 9. Now we can use this template file to generate translation files for each of the languages we listed in the LINGUAS file with the following command:
 
    ```bash
-   ninja com.github.yourusername.yourrepositoryname-update-po
+   ninja io.github.yourusername.yourrepositoryname-update-po
    ```
 
    You should notice two new files in your po directory called `de.po` and `es.po`. These files are now ready for translators to localize your app!


### PR DESCRIPTION
Fixes #158
Replaced with: `$ git grepn -l com.github | xargs sed -i "s/com\(.\)github/io\1github/g"`

---

We should not use the "com.github" prefix because we don't have any control over the "github.com" domain.

See also:

- https://docs.flatpak.org/en/latest/conventions.html
- https://docs.flathub.org/docs/for-app-authors/requirements