### PR TITLE
Replace deprecated source_root with project_source_root

### DIFF
--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -9,8 +9,11 @@ The next thing we need is a build system. The build system that we're going to b
 Create a new file in your project's root folder called "meson.build". We've included some comments along the way to explain what each section does. You don't have to copy those, but type the rest into that file:
 
 ```coffeescript
-# project name and programming language
-project('io.github.yourusername.yourrepositoryname', 'vala', 'c')
+# project name, programming language, and required meson version
+project('io.github.yourusername.yourrepositoryname',
+    'vala', 'c',
+    meson_version: '>= 0.56.0'
+)
 
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install
 executable(

--- a/writing-apps/our-first-app/translations.md
+++ b/writing-apps/our-first-app/translations.md
@@ -31,7 +31,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
    i18n.merge_file(
        input: 'data' / 'hello-again.desktop.in',
        output: meson.project_name() + '.desktop',
-       po_dir: meson.source_root() / 'po',
+       po_dir: meson.project_source_root() / 'po',
        type: 'desktop',
        install: true,
        install_dir: get_option('datadir') / 'applications'
@@ -41,7 +41,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
    i18n.merge_file(
        input: 'data' / 'hello-again.metainfo.xml.in',
        output: meson.project_name() + '.metainfo.xml',
-       po_dir: meson.source_root() / 'po',
+       po_dir: meson.project_source_root() / 'po',
        install: true,
        install_dir: get_option('datadir') / 'metainfo'
    )
@@ -68,7 +68,7 @@ Now we have to make some changes to our Meson build system and add a couple new 
 
    ```coffeescript
    i18n.gettext(meson.project_name(),
-       args: '--directory=' + meson.source_root(),
+       args: '--directory=' + meson.project_source_root(),
        preset: 'glib'
    )
    ```


### PR DESCRIPTION
meson.source_root() was deprecated in 0.56.0, so don't use it in our documentation too.