### PR TITLE
Correct ninja comman to uninstall the app

### DIFF
--- a/writing-apps/our-first-app/the-build-system.md
+++ b/writing-apps/our-first-app/the-build-system.md
@@ -74,7 +74,7 @@ If you were about to add the "build" folder to your git repository and push it, 
 To uninstall your application, change into the build directory and we will use `ninja` once again to uninstall:
 
 ```bash
-sudo ninja -C build uninstall
+sudo ninja uninstall
 ```
 
 If all went well, you should see command output that shows files related to your application were removed.  Again, more details can be found in [Meson's documentation](https://mesonbuild.com/Manual.html).


### PR DESCRIPTION
Before this command we say "change into the build directory", so we don't need to explicit the build directory with the "-C" option.