### PR TITLE
Replace deprecated FLAGS_NONE with DEFAULT_FLAGS in writing-apps

### DIFF
--- a/writing-apps/hello-world.md
+++ b/writing-apps/hello-world.md
@@ -24,7 +24,7 @@ public class MyApp : Gtk.Application {
     public MyApp () {
         Object (
             application_id: "io.github.yourusername.yourrepositoryname",
-            flags: ApplicationFlags.FLAGS_NONE
+            flags: ApplicationFlags.DEFAULT_FLAGS
         );
     }
 

--- a/writing-apps/our-first-app/README.md
+++ b/writing-apps/our-first-app/README.md
@@ -28,7 +28,7 @@ The results should look like this:
     public MyApp () {
         Object (
             application_id: "io.github.yourusername.yourrepositoryname",
-            flags: ApplicationFlags.FLAGS_NONE
+            flags: ApplicationFlags.DEFAULT_FLAGS
         );
     }
 

--- a/writing-apps/panes.md
+++ b/writing-apps/panes.md
@@ -122,7 +122,7 @@ public class MyApp : Gtk.Application {
     public MyApp () {
         Object (
             application_id: "io.github.myteam.myapp",
-            flags: ApplicationFlags.FLAGS_NONE
+            flags: ApplicationFlags.DEFAULT_FLAGS
         );
     }
 


### PR DESCRIPTION
Running through the writing-apps documentation I got a warning when using the `flags: ApplicationFlags.FLAGS_NONE`. It looks like through my research the correct flag now is `flags: ApplicationFlags.DEFAULT_FLAGS`